### PR TITLE
Added the ability for the dev to choose which edge(s) that the ChatHead will snap

### DIFF
--- a/ChatHeads/AppDelegate.m
+++ b/ChatHeads/AppDelegate.m
@@ -30,6 +30,7 @@
     
     _draggingCoordinator = [[CHDraggingCoordinator alloc] initWithWindow:self.window draggableViewBounds:draggableView.bounds];
     _draggingCoordinator.delegate = self;
+    _draggingCoordinator.snappingEdge = CHSnappingEdgeBoth;
     draggableView.delegate = _draggingCoordinator;
     
     [self.window addSubview:draggableView];

--- a/ChatHeads/Classes/CHDraggingCoordinator.h
+++ b/ChatHeads/Classes/CHDraggingCoordinator.h
@@ -10,9 +10,16 @@
 
 #import "CHDraggableView.h"
 
+typedef enum {
+    CHSnappingEdgeBoth,
+    CHSnappingEdgeRight,
+    CHSnappingEdgeLeft
+} CHSnappingEdge;
+
 @protocol CHDraggingCoordinatorDelegate;
 @interface CHDraggingCoordinator : NSObject <CHDraggableViewDelegate>
 
+@property (nonatomic) CHSnappingEdge snappingEdge;
 @property (nonatomic, weak) id<CHDraggingCoordinatorDelegate> delegate;
 
 - (id)initWithWindow:(UIWindow *)window draggableViewBounds:(CGRect)bounds;

--- a/ChatHeads/Classes/CHDraggingCoordinator.m
+++ b/ChatHeads/Classes/CHDraggingCoordinator.m
@@ -74,11 +74,21 @@ typedef enum {
     CGRectEdge destinationEdge = [self _destinationEdgeForReleasePointInCurrentState:releasePoint];
     CGFloat destinationX;
     CGFloat destinationY = MAX(releasePoint.y, CGRectGetMinY(dropArea) + CGRectGetMidY(_draggableViewBounds));
-    if (destinationEdge == CGRectMinXEdge) {
+
+    if (self.snappingEdge == CHSnappingEdgeBoth){   //ChatHead will snap to both edges
+        if (destinationEdge == CGRectMinXEdge) {
+            destinationX = CGRectGetMinX(dropArea) + midXDragView;
+        } else {
+            destinationX = CGRectGetMaxX(dropArea) - midXDragView;
+        }
+        
+    }else if(self.snappingEdge == CHSnappingEdgeLeft){  //ChatHead will snap only to left edge
         destinationX = CGRectGetMinX(dropArea) + midXDragView;
-    } else {
+        
+    }else{  //ChatHead will snap only to right edge
         destinationX = CGRectGetMaxX(dropArea) - midXDragView;
     }
+
     return CGPointMake(destinationX, destinationY);
 }
 


### PR DESCRIPTION
Now the developer can choose which edge(s) that the ChatHead will snap: CHSnappingEdgeBoth, CHSnappingEdgeRight and CHSnappingEdgeLeft.
To set which edge you want to use, simply call

``` objective-c
_draggingCoordinator.snappingEdge = CHSnappingEdgeBoth;
```

_draggingCoordinator being the CHDraggingCoordinator.

Thanks!
