### PR TITLE
add license title

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,5 @@
+ISC License
+
 Copyright (c) 2013, Matthias Hochgatterer <matthias.hochgatterer@gmail.com>
 
 Permission to use, copy, modify, and/or distribute this software for any


### PR DESCRIPTION
It's not legally required, but it's useful metadata, and part of the recommended license template text:
- http://choosealicense.com/licenses/isc/
- https://opensource.org/licenses/isc-license
- http://spdx.org/licenses/ISC.html#licenseText
